### PR TITLE
Fix metadata file handling

### DIFF
--- a/src/1.2.3-clean-pdf.py
+++ b/src/1.2.3-clean-pdf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-""" step 1.2.3-clean-pdf.py """
+"""step 1.2.3-clean-pdf.py"""
 
 import fitz
 import json
@@ -23,8 +23,8 @@ def optimize_pdf(input_pdf_path, output_pdf_path):
 
     doc = fitz.open(input_pdf_path)
     existing_metadata = doc.metadata
-    with open("metadata.json", "w", encoding("UTF-8")) as mdout:
-        json.dump(existing_metadata, meta_file, indent=4)
+    with open("metadata.json", "w", encoding="UTF-8") as mdout:
+        json.dump(existing_metadata, mdout, indent=4)
 
     new_doc = fitz.open()
 


### PR DESCRIPTION
## Summary
- fix how pdf cleaning script dumps metadata

## Testing
- `black src/1.2.3-clean-pdf.py`
- `black --check src/1.2.3-clean-pdf.py`
- `pylint src/1.2.3-clean-pdf.py`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6840b1f685088328b67f613ce98c88dc