### PR TITLE
Add joblib import

### DIFF
--- a/src/3.2-ml-model.py
+++ b/src/3.2-ml-model.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import sys
+import joblib
 
 
 class MLMapper:


### PR DESCRIPTION
## Summary
- add missing `joblib` import in the ML model script

## Testing
- `python3 src/3.2-ml-model.py --help` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840b1cd37208328a2bff521229e08da