### PR TITLE
Fix saveas invocation

### DIFF
--- a/src/2.0-nlp.py
+++ b/src/2.0-nlp.py
@@ -312,7 +312,7 @@ def saveas_xml(doc, out_file):
 
 def saveas(out_type, doc, out_file):
     if out_type == "text":
-        saveas_txt(doc, out_file)
+        saveas_text(doc, out_file)
 
     if out_type == "html":
         saveas_html(doc, out_file)
@@ -373,7 +373,7 @@ def main(args):
             logger.error(f"Failed nlp: {err}, skipping...")
             continue
 
-        saveas(format=params.output_type, doc=doc, out_file=out_file)
+        saveas(out_type=params.output_type, doc=doc, out_file=out_file)
 
         if Path(out_file).exists():
             logger.info(out_file.resolve())


### PR DESCRIPTION
## Summary
- call `saveas_text()` inside `saveas()`
- call `saveas()` with `out_type` parameter in `main`

## Testing
- `python - <<'EOF'
import importlib.util, sys
from pathlib import Path
import spacy
spec = importlib.util.spec_from_file_location('nlp', 'src/2.0-nlp.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

nlp = spacy.load('en_core_web_sm')
doc = nlp('Hello world! Jane Doe visited New York in 2020.')
module.saveas(out_type='text', doc=doc, out_file=Path('sample_out.text'))
print('file exists:', Path('sample_out.text').exists())
EOF

------
https://chatgpt.com/codex/tasks/task_e_6840b1cd07a883289d94935586b07800