### PR TITLE
Fix parse_args call

### DIFF
--- a/src/1.2.1-clean-image.py
+++ b/src/1.2.1-clean-image.py
@@ -213,7 +213,7 @@ def process_image(input_path, output_path, args):
 
 
 def main(args):
-    params = argp.parse_args(args)
+    params = parse_args(args)
     process_image(params.input, params.output, params)
 
 


### PR DESCRIPTION
## Summary
- call `parse_args()` from `main()` in the clean image script

## Testing
- `python src/1.2.1-clean-image.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6840bfc157c883289131250c27e23339